### PR TITLE
Switch to HTTPS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cabal-env
 
-`cabal-env` is a prototype UI for managing the new [package environments](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/packages.html#package-environments) facility implement in GHC for use by cabal's [nix-style local builds](http://cabal.readthedocs.io/en/latest/nix-local-build-overview.html) which allows to provide seamless access to the nix-style package store for direct invocations GHC and GHCi.
+`cabal-env` is a prototype UI for managing the new [package environments](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/packages.html#package-environments) facility implement in GHC for use by cabal's [nix-style local builds](https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html) which allows to provide seamless access to the nix-style package store for direct invocations GHC and GHCi.
 
 ## Usage
 


### PR DESCRIPTION
[cabal.readthedocs.io](cabal.readthedocs.io) is available over HTTPS, so let’s link to that version.